### PR TITLE
외형검색/TAR 브라우저 네비게이션 타임아웃 안정화

### DIFF
--- a/src/main/kotlin/feature/eorzea/EorzeaCollectionGlamourClient.kt
+++ b/src/main/kotlin/feature/eorzea/EorzeaCollectionGlamourClient.kt
@@ -2,12 +2,17 @@ package feature.eorzea
 
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.WaitUntilState
 import feature.webdriver.PlaywrightBrowserFactory
 import org.slf4j.LoggerFactory
 
 private const val EORZEA_BASE_URL = "https://ffxiv.eorzeacollection.com"
 private const val EORZEA_GLAMOURS_URL =
     "https://ffxiv.eorzeacollection.com/glamours?filter%5BorderBy%5D=loves&filter%5BdatePeriod%5D=past-year&filter%5Bgender%5D=any&filter%5Bserver%5D=any&search=&author=&filter%5Bclass%5D=&filter%5Bstyle%5D=&filter%5Btheme%5D=&filter%5Bcolor%5D=&filter%5Bjob%5D=all&filter%5BminimumLvl%5D=1&filter%5BmaximumLvl%5D=100&filter%5BheadPiece%5D=&filter%5BbodyPiece%5D=&filter%5BhandsPiece%5D=&filter%5BlegsPiece%5D=&filter%5BfeetPiece%5D=&filter%5BweaponPiece%5D=&filter%5BoffhandPiece%5D=&filter%5BearringsPiece%5D=&filter%5BnecklacePiece%5D=&filter%5BbraceletsPiece%5D=&filter%5BringPiece%5D=&filter%5BfashionPiece%5D=&filter%5BfacePiece%5D=&page=1"
+private const val EORZEA_NAVIGATION_TIMEOUT_MS = 60_000.0
+private const val EORZEA_NAVIGATION_MAX_ATTEMPTS = 2
+private const val EORZEA_NAVIGATION_RETRY_DELAY_MS = 700.0
+private const val EORZEA_FILTER_INPUT_WAIT_TIMEOUT_MS = 15_000L
 
 private val logger = LoggerFactory.getLogger(EorzeaCollectionGlamourClient::class.java)
 
@@ -57,8 +62,7 @@ class EorzeaCollectionGlamourClient {
 
                 val navigateStartedAt = System.nanoTime()
                 logger.info("[EORZEA] 목록 페이지 접속 시도")
-                page.navigate(EORZEA_GLAMOURS_URL)
-                page.waitForLoadState()
+                navigateWithRetry(page, EORZEA_GLAMOURS_URL, "목록")
                 logger.info("[EORZEA] 목록 페이지 접속 완료: elapsedMs={}", elapsedMs(navigateStartedAt))
                 checkCloudflareBlocked(page)
 
@@ -122,11 +126,20 @@ class EorzeaCollectionGlamourClient {
             "input[name='filter[${slot.filterParam}]']",
             "xpath=//input[contains(translate(@placeholder,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'any') and " +
                 "contains(translate(@placeholder,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'$slotToken')]",
-            "xpath=//input[contains(translate(@aria-label,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'$slotToken')]"
+                "xpath=//input[contains(translate(@aria-label,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'$slotToken')]"
         )
 
-        return firstVisibleLocator(page, selectors)
-            ?: throw IllegalStateException("Eorzea 필터 입력 필드를 찾지 못했습니다. slot=${slot.filterParam}")
+        val deadlineAt = System.currentTimeMillis() + EORZEA_FILTER_INPUT_WAIT_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadlineAt) {
+            checkCloudflareBlocked(page)
+            val visibleInput = firstVisibleLocator(page, selectors)
+            if (visibleInput != null) return visibleInput
+            page.waitForTimeout(250.0)
+        }
+
+        throw IllegalStateException(
+            "Eorzea 필터 입력 필드를 찾지 못했습니다. slot=${slot.filterParam}, title=${page.title()}, url=${page.url()}"
+        )
     }
 
     private fun firstVisibleLocator(page: Page, selectors: List<String>): Locator? =
@@ -239,12 +252,66 @@ class EorzeaCollectionGlamourClient {
     }
 
     private fun checkCloudflareBlocked(page: Page) {
-        val titleBlocked = page.title().contains("Attention Required", ignoreCase = true)
-        val bodyBlocked = page.content().contains("cf-error-details", ignoreCase = true)
-        if (titleBlocked || bodyBlocked) {
-            logger.warn("[EORZEA] Cloudflare 차단 감지: titleBlocked={}, bodyBlocked={}", titleBlocked, bodyBlocked)
+        val title = runCatching { page.title() }.getOrDefault("")
+        val url = runCatching { page.url() }.getOrDefault("")
+        val content = runCatching { page.content() }.getOrDefault("")
+
+        val titleBlocked = title.contains("Attention Required", ignoreCase = true) ||
+            title.contains("Just a moment", ignoreCase = true) ||
+            title.contains("Checking your browser", ignoreCase = true)
+        val bodyBlocked = content.contains("cf-error-details", ignoreCase = true) ||
+            content.contains("challenge-platform", ignoreCase = true) ||
+            content.contains("cf_chl", ignoreCase = true)
+        val urlBlocked = url.contains("/cdn-cgi/challenge-platform", ignoreCase = true)
+
+        if (titleBlocked || bodyBlocked || urlBlocked) {
+            logger.warn(
+                "[EORZEA] Cloudflare 차단 감지: titleBlocked={}, bodyBlocked={}, urlBlocked={}, title={}, url={}",
+                titleBlocked,
+                bodyBlocked,
+                urlBlocked,
+                title,
+                url
+            )
             throw IllegalStateException("Eorzea Collection 접근이 차단되었습니다. Cloudflare 차단 상태를 확인해주세요.")
         }
+    }
+
+    private fun navigateWithRetry(page: Page, url: String, stepName: String) {
+        var lastError: Throwable? = null
+
+        repeat(EORZEA_NAVIGATION_MAX_ATTEMPTS) { attempt ->
+            val attemptNo = attempt + 1
+            val succeeded = runCatching {
+                page.navigate(
+                    url,
+                    Page.NavigateOptions()
+                        .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                        .setTimeout(EORZEA_NAVIGATION_TIMEOUT_MS)
+                )
+            }.onFailure { error ->
+                lastError = error
+                logger.warn(
+                    "[EORZEA] {} 페이지 접속 실패: attempt={}/{}, url={}, message={}",
+                    stepName,
+                    attemptNo,
+                    EORZEA_NAVIGATION_MAX_ATTEMPTS,
+                    url,
+                    error.message
+                )
+            }.isSuccess
+
+            if (succeeded) return
+
+            if (attemptNo < EORZEA_NAVIGATION_MAX_ATTEMPTS) {
+                page.waitForTimeout(EORZEA_NAVIGATION_RETRY_DELAY_MS)
+            }
+        }
+
+        throw IllegalStateException(
+            "Eorzea $stepName 페이지 접속에 실패했습니다. url=$url",
+            lastError
+        )
     }
 
     private fun normalizeText(input: String): String =

--- a/src/main/kotlin/feature/tar/TarItemSearchClient.kt
+++ b/src/main/kotlin/feature/tar/TarItemSearchClient.kt
@@ -1,6 +1,8 @@
 package feature.tar
 
 import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.WaitUntilState
 import dev.kord.rest.NamedFile
 import feature.webdriver.PlaywrightBrowserFactory
 import io.ktor.client.request.forms.ChannelProvider
@@ -13,6 +15,9 @@ import java.nio.charset.StandardCharsets
 import kotlin.io.path.createTempFile
 
 private val logger = LoggerFactory.getLogger(TarItemSearchClient::class.java)
+private const val TAR_NAVIGATION_TIMEOUT_MS = 60_000.0
+private const val TAR_NAVIGATION_MAX_ATTEMPTS = 2
+private const val TAR_NAVIGATION_RETRY_DELAY_MS = 500.0
 
 data class TarItemMatchedResult(
     val itemName: String,
@@ -52,7 +57,7 @@ class TarItemSearchClient {
                 val page = session.page
                 val listNavigateStartedAt = System.nanoTime()
                 logger.info("[TAR] 목록 페이지 접속 시도")
-                page.navigate(listUrl)
+                navigateWithRetry(page, listUrl, "목록")
                 logger.info(
                     "[TAR] 목록 페이지 접속 완료: elapsedMs={}",
                     elapsedMs(listNavigateStartedAt)
@@ -88,7 +93,7 @@ class TarItemSearchClient {
                 logger.info("[TAR] 항목 선택 완료: pageLink={}, itemId={}", itemPageLink, itemIdFromSearchResult)
 
                 val itemNavigateStartedAt = System.nanoTime()
-                page.navigate(itemPageLink)
+                navigateWithRetry(page, itemPageLink, "상세")
                 logger.info(
                     "[TAR] 아이템 상세 페이지 접속 완료: elapsedMs={}",
                     elapsedMs(itemNavigateStartedAt)
@@ -138,6 +143,43 @@ class TarItemSearchClient {
             )
             throw e
         }
+    }
+
+    private fun navigateWithRetry(page: Page, url: String, stepName: String) {
+        var lastError: Throwable? = null
+
+        repeat(TAR_NAVIGATION_MAX_ATTEMPTS) { attempt ->
+            val attemptNo = attempt + 1
+            val succeeded = runCatching {
+                page.navigate(
+                    url,
+                    Page.NavigateOptions()
+                        .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                        .setTimeout(TAR_NAVIGATION_TIMEOUT_MS)
+                )
+            }.onFailure { error ->
+                lastError = error
+                logger.warn(
+                    "[TAR] {} 페이지 접속 실패: attempt={}/{}, url={}, message={}",
+                    stepName,
+                    attemptNo,
+                    TAR_NAVIGATION_MAX_ATTEMPTS,
+                    url,
+                    error.message
+                )
+            }.isSuccess
+
+            if (succeeded) return
+
+            if (attemptNo < TAR_NAVIGATION_MAX_ATTEMPTS) {
+                page.waitForTimeout(TAR_NAVIGATION_RETRY_DELAY_MS)
+            }
+        }
+
+        throw IllegalStateException(
+            "TAR $stepName 페이지 접속에 실패했습니다. url=$url",
+            lastError
+        )
     }
 
     private fun captureContentsScreenshot(contentsLocator: Locator): File {


### PR DESCRIPTION
## 개요

- Docker 컨테이너 환경에서 `/외형검색` 및 TAR 검색 시 간헐적으로 발생하던 Playwright `Timeout 30000ms exceeded` 문제를 완화하기 위해 네비게이션 대기 전략을 보강했습니다.
- 기존 `load` 이벤트 단일 대기에서 `domcontentloaded + 재시도` 패턴으로 변경해 초기 페이지 진입 지연에 대한 내성을 높였습니다.
- Eorzea 필터 입력 필드 탐색 실패 시점에 진단 정보를 보강해 운영 로그 기반 원인 파악이 가능하도록 개선했습니다.

## 주요 변경 사항

- `EorzeaCollectionGlamourClient`의 목록 페이지 접속을 `60초 timeout + 최대 2회 재시도`로 변경했습니다.
- Eorzea 필터 입력 필드 탐색에 명시적 대기 루프(최대 15초)를 추가하고, 실패 시 `slot/title/url`을 포함한 예외 메시지를 반환하도록 수정했습니다.
- Cloudflare 차단 감지를 title/body/url 패턴까지 확장해 차단 상태를 일반 로딩 지연과 구분할 수 있도록 보강했습니다.
- `TarItemSearchClient`의 목록/상세 페이지 이동도 동일한 `domcontentloaded + 재시도` 전략으로 통일했습니다.

## 커밋 목록

- `42a2478` Eorzea/TAR 브라우저 네비게이션 타임아웃을 재시도 기반으로 안정화

## 통계

- 비교 기준: `origin/main...feat/stabilize-browser-timeouts`
- 변경 파일 수: 2
- 추가/삭제: `+120 / -11`
- 주요 변경 파일:
  - `src/main/kotlin/feature/eorzea/EorzeaCollectionGlamourClient.kt`
  - `src/main/kotlin/feature/tar/TarItemSearchClient.kt`

## 참고 사항

- 테스트/빌드: ` /tmp/gradle-dist/gradle-8.2/bin/gradle --no-daemon -p /root/code/RomangWay test ` 실행 성공
- 운영/배포 영향: 기능 변경 없이 네비게이션/탐색 안정성 및 오류 진단 로그를 강화한 패치입니다.
- 리뷰 포인트:
  - 컨테이너 환경에서 `외형검색`의 초기 진입 실패율이 감소하는지 확인 필요
  - Cloudflare 차단 감지 로그(title/url/body 패턴)가 실제 차단 케이스에서 의도대로 분리되는지 확인 필요
