### PR TITLE
FFLogs 로그 커맨드 UX 개선 및 Components V2 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.kord:kord-core:0.17.0")
+    implementation("dev.kord:kord-core:0.18.0")
     testImplementation(kotlin("test"))
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ plugins {
 }
 
 group = "creat.xinkle"
-version = "1.6"
+version = "1.7"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -20,6 +20,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 private val logger = LoggerFactory.getLogger("Main")
 private const val LEGACY_GLAMOUR_COMMAND = "외형검색"
+private const val LEGACY_FFLOG_COMMAND = "프프로그"
 
 suspend fun main() = withContext(Dispatchers.IO) {
     logger.info("Romangway 애플리케이션 시작")
@@ -48,6 +49,7 @@ suspend fun main() = withContext(Dispatchers.IO) {
     }
     logger.info("기존 글로벌 커맨드 목록 조회 완료: {}개", existingCommands.size)
     deleteLegacyCommandIfExists(kord, existingCommands, LEGACY_GLAMOUR_COMMAND)
+    deleteLegacyCommandIfExists(kord, existingCommands, LEGACY_FFLOG_COMMAND)
 
     // FFLog 클라이언트 초기화 및 토큰 갱신
     logger.info("FFLog 클라이언트 초기화 및 토큰 갱신 시작")

--- a/src/main/kotlin/feature/FFLogRankingFeature.kt
+++ b/src/main/kotlin/feature/FFLogRankingFeature.kt
@@ -2,6 +2,7 @@ package feature
 
 import creat.xinkle.Romangway.GetFFlogRanking
 import creat.xinkle.Romangway.GetFFlogSavageZones
+import dev.kord.common.entity.MessageFlag
 import dev.kord.core.Kord
 import dev.kord.core.behavior.edit
 import dev.kord.core.behavior.interaction.updateEphemeralMessage
@@ -11,16 +12,19 @@ import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.event.interaction.GuildSelectMenuInteractionCreateEvent
 import dev.kord.core.on
 import dev.kord.rest.builder.component.ActionRowBuilder
+import dev.kord.rest.builder.component.ContainerBuilder
+import dev.kord.rest.builder.component.MessageComponentBuilder
 import dev.kord.rest.builder.component.option
+import dev.kord.rest.builder.message.messageFlags
 import feature.model.FFlogRanking
+import feature.model.FFlogParseColorTier
 import feature.model.FFlogRankingSummary
 import feature.model.FFlogZones
 import fflog.FFlogJson
 import fflog.FFLogClient
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import dev.kord.rest.builder.message.EmbedBuilder
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -86,15 +90,17 @@ class FFLogFeature(
 
                 if (session.isPublic) {
                     interaction.updatePublicMessage {
-                        content = ""
-                        embeds = mutableListOf(buildRankingEmbed(session, selectedSummary))
-                        components = mutableListOf(buildRankingSelectActionRow(sessionId, session.summaries, selectedIndex))
+                        messageFlags { +MessageFlag.IsComponentsV2 }
+                        content = null
+                        embeds = null
+                        components = buildRankingComponents(session, selectedSummary, sessionId, selectedIndex)
                     }
                 } else {
                     interaction.updateEphemeralMessage {
-                        content = ""
-                        embeds = mutableListOf(buildRankingEmbed(session, selectedSummary))
-                        components = mutableListOf(buildRankingSelectActionRow(sessionId, session.summaries, selectedIndex))
+                        messageFlags { +MessageFlag.IsComponentsV2 }
+                        content = null
+                        embeds = null
+                        components = buildRankingComponents(session, selectedSummary, sessionId, selectedIndex)
                     }
                 }
             }
@@ -170,15 +176,17 @@ class FFLogFeature(
         val originalResponse = interaction.getOriginalInteractionResponseOrNull()
         if (originalResponse != null) {
             originalResponse.edit {
+                messageFlags { +MessageFlag.IsComponentsV2 }
+                content = null
+                embeds = null
                 if (summaries.isEmpty()) {
-                    embeds = mutableListOf(
-                        buildNoClearRankingEmbed(
+                    components = mutableListOf(
+                        buildNoClearRankingContainer(
                             raidName = currentTopSavageZone.zoneName,
                             name = name,
                             server = server
                         )
                     )
-                    components?.clear()
                 } else {
                     val defaultIndex = 0
                     val selectedSummary = summaries[defaultIndex]
@@ -192,38 +200,28 @@ class FFLogFeature(
                         summaries = summaries
                     )
 
-                    embeds = mutableListOf(
-                        buildRankingEmbed(
-                            session = rankingSelectSessions.getValue(sessionId),
-                            selectedSummary = selectedSummary
-                        )
+                    components = buildRankingComponents(
+                        session = rankingSelectSessions.getValue(sessionId),
+                        selectedSummary = selectedSummary,
+                        sessionId = sessionId,
+                        selectedIndex = defaultIndex
                     )
-                    if (summaries.size > 1) {
-                        components = mutableListOf(
-                            buildRankingSelectActionRow(
-                                sessionId = sessionId,
-                                summaries = summaries,
-                                selectedIndex = defaultIndex
-                            )
-                        )
-                    } else {
-                        components?.clear()
-                    }
                 }
-                content = ""
             }
         } else {
             logger.warn("원본 응답이 없어 최종 결과를 신규 응답으로 전송합니다.")
             response.respond {
+                messageFlags { +MessageFlag.IsComponentsV2 }
+                content = null
+                embeds = null
                 if (summaries.isEmpty()) {
-                    embeds = mutableListOf(
-                        buildNoClearRankingEmbed(
+                    components = mutableListOf(
+                        buildNoClearRankingContainer(
                             raidName = currentTopSavageZone.zoneName,
                             name = name,
                             server = server
                         )
                     )
-                    components?.clear()
                 } else {
                     val defaultIndex = 0
                     val selectedSummary = summaries[defaultIndex]
@@ -237,25 +235,13 @@ class FFLogFeature(
                         summaries = summaries
                     )
 
-                    embeds = mutableListOf(
-                        buildRankingEmbed(
-                            session = rankingSelectSessions.getValue(sessionId),
-                            selectedSummary = selectedSummary
-                        )
+                    components = buildRankingComponents(
+                        session = rankingSelectSessions.getValue(sessionId),
+                        selectedSummary = selectedSummary,
+                        sessionId = sessionId,
+                        selectedIndex = defaultIndex
                     )
-                    if (summaries.size > 1) {
-                        components = mutableListOf(
-                            buildRankingSelectActionRow(
-                                sessionId = sessionId,
-                                summaries = summaries,
-                                selectedIndex = defaultIndex
-                            )
-                        )
-                    } else {
-                        components?.clear()
-                    }
                 }
-                content = ""
             }
         }
     }
@@ -290,31 +276,53 @@ class FFLogFeature(
         return fflogRanking
     }
 
-    private fun buildRankingEmbed(
+    private fun buildRankingContainer(
         session: RankingSelectSession,
         selectedSummary: FFlogRankingSummary
-    ): EmbedBuilder = EmbedBuilder().apply {
-        title = session.raidName
-        description = """
-            이름: ${session.name}
-            서버: ${session.server}
+    ): ContainerBuilder {
+        val colorTier = FFlogParseColorTier.fromAllStarPercent(selectedSummary.allStarPercentValueOrNull())
+        return ContainerBuilder().apply {
+            accentColor = colorTier.accentColor
+            textDisplay(
+                """
+                ## ${session.raidName}
+                이름: ${session.name}
+                서버: ${session.server}
 
-            ${selectedSummary.toDetailDescriptionWithoutIdentity()}
-        """.trimIndent()
+                ${selectedSummary.toDetailDescriptionWithoutIdentity()}
+                파스 색상 등급: ${colorTier.label}
+                """.trimIndent()
+            )
+        }
     }
 
-    private fun buildNoClearRankingEmbed(
+    private fun buildNoClearRankingContainer(
         raidName: String,
         name: String,
         server: String
-    ): EmbedBuilder = EmbedBuilder().apply {
-        title = raidName
-        description = """
+    ): ContainerBuilder = ContainerBuilder().apply {
+        accentColor = FFlogParseColorTier.GRAY.accentColor
+        textDisplay(
+            """
+            ## $raidName
             이름: $name
             서버: $server
 
             클리어 기록 없음
-        """.trimIndent()
+            """.trimIndent()
+        )
+    }
+
+    private fun buildRankingComponents(
+        session: RankingSelectSession,
+        selectedSummary: FFlogRankingSummary,
+        sessionId: String,
+        selectedIndex: Int
+    ): MutableList<MessageComponentBuilder> = mutableListOf<MessageComponentBuilder>().apply {
+        add(buildRankingContainer(session, selectedSummary))
+        if (session.summaries.size > 1) {
+            add(buildRankingSelectActionRow(sessionId, session.summaries, selectedIndex))
+        }
     }
 
     private fun buildRankingSelectActionRow(

--- a/src/main/kotlin/feature/FFLogRankingFeature.kt
+++ b/src/main/kotlin/feature/FFLogRankingFeature.kt
@@ -55,7 +55,7 @@ class FFLogFeature(
         "펜리르" to "Fenrir",
         "모그리" to "Moogle"
     )
-    override val command: String = "프프로그"
+    override val command: String = "로그"
 
     override val arguments: List<CommandArgument> = listOf(
         CommandArgument(
@@ -68,13 +68,18 @@ class FFLogFeature(
             ARGUMENT_SERVER,
             "가져올 유저의 서버",
             true,
-            ArgumentType.STRING
+            ArgumentType.STRING,
+            choices = serverMapping.keys.map { it to it }
         ),
         CommandArgument(
             ARGUMENT_EXPOSABLE,
             "조회한 로그의 공개여부",
             true,
-            ArgumentType.BOOLEAN
+            ArgumentType.STRING,
+            choices = listOf(
+                "공개" to "공개",
+                "비공개" to "비공개"
+            )
         )
     )
 
@@ -112,7 +117,13 @@ class FFLogFeature(
 
         val name = command.strings[ARGUMENT_NAME]!!
         val server = command.strings[ARGUMENT_SERVER]!!
-        val isExposable = command.booleans[ARGUMENT_EXPOSABLE]!!
+        val exposableOption = command.strings[ARGUMENT_EXPOSABLE]
+        val isExposable = when (exposableOption) {
+            "공개" -> true
+            "비공개" -> false
+            null -> command.booleans[ARGUMENT_EXPOSABLE]
+            else -> null
+        } ?: error("공개여부 값이 올바르지 않습니다.")
         val mappedServer = serverMapping[server]
 
         val response = if (isExposable) {

--- a/src/main/kotlin/feature/FFLogRankingFeature.kt
+++ b/src/main/kotlin/feature/FFLogRankingFeature.kt
@@ -284,14 +284,21 @@ class FFLogFeature(
         return ContainerBuilder().apply {
             accentColor = colorTier.accentColor
             textDisplay(
-                """
-                ## ${session.raidName}
-                이름: ${session.name}
-                서버: ${session.server}
-
-                ${selectedSummary.toDetailDescriptionWithoutIdentity()}
-                파스 색상 등급: ${colorTier.label}
-                """.trimIndent()
+                buildString {
+                    appendLine("## ${session.raidName}")
+                    appendLine("이름: ${session.name}")
+                    appendLine("서버: ${session.server}")
+                    appendLine()
+                    appendLine("직업: ${selectedSummary.toEmbedFieldName()}")
+                    appendLine("올스타 포인트: ${selectedSummary.allStarPoint ?: "N/A"}")
+                    appendLine("올스타 백분위: ${selectedSummary.allStarPercent ?: "N/A"}")
+                    appendLine("올스타 등수: ${selectedSummary.allStarRankings ?: "N/A"}")
+                    appendLine("1층: ${selectedSummary.firstFloor ?: "N/A"}")
+                    appendLine("2층: ${selectedSummary.secondFloor ?: "N/A"}")
+                    appendLine("3층: ${selectedSummary.thirdFloor ?: "N/A"}")
+                    appendLine("4층전반: ${selectedSummary.fourthFloor ?: "N/A"}")
+                    append("4층후반: ${selectedSummary.fifthFloor ?: "N/A"}")
+                }
             )
         }
     }
@@ -303,13 +310,13 @@ class FFLogFeature(
     ): ContainerBuilder = ContainerBuilder().apply {
         accentColor = FFlogParseColorTier.GRAY.accentColor
         textDisplay(
-            """
-            ## $raidName
-            이름: $name
-            서버: $server
-
-            클리어 기록 없음
-            """.trimIndent()
+            buildString {
+                appendLine("## $raidName")
+                appendLine("이름: $name")
+                appendLine("서버: $server")
+                appendLine()
+                append("클리어 기록 없음")
+            }
         )
     }
 

--- a/src/main/kotlin/feature/model/FFlogParseColorTier.kt
+++ b/src/main/kotlin/feature/model/FFlogParseColorTier.kt
@@ -1,0 +1,32 @@
+package feature.model
+
+import dev.kord.common.Color
+
+enum class FFlogParseColorTier(
+    val label: String,
+    val accentColor: Color
+) {
+    GRAY("회색", Color(102, 102, 102)),
+    GREEN("초록", Color(30, 255, 0)),
+    BLUE("파랑", Color(0, 112, 255)),
+    PURPLE("보라", Color(163, 53, 238)),
+    ORANGE("주황", Color(255, 128, 0)),
+    PINK("핑크", Color(226, 104, 168)),
+    GOLD("골드", Color(229, 204, 128));
+
+    companion object {
+        fun fromAllStarPercent(percent: Double?): FFlogParseColorTier {
+            if (percent == null) return GRAY
+
+            return when {
+                percent >= 100.0 -> GOLD
+                percent >= 99.0 -> PINK
+                percent >= 95.0 -> ORANGE
+                percent >= 75.0 -> PURPLE
+                percent >= 50.0 -> BLUE
+                percent >= 25.0 -> GREEN
+                else -> GRAY
+            }
+        }
+    }
+}

--- a/src/main/kotlin/feature/model/FFlogParseColorTier.kt
+++ b/src/main/kotlin/feature/model/FFlogParseColorTier.kt
@@ -4,27 +4,31 @@ import dev.kord.common.Color
 
 enum class FFlogParseColorTier(
     val label: String,
-    val accentColor: Color
+    val hexColor: Int
 ) {
-    GRAY("회색", Color(102, 102, 102)),
-    GREEN("초록", Color(30, 255, 0)),
-    BLUE("파랑", Color(0, 112, 255)),
-    PURPLE("보라", Color(163, 53, 238)),
-    ORANGE("주황", Color(255, 128, 0)),
-    PINK("핑크", Color(226, 104, 168)),
-    GOLD("골드", Color(229, 204, 128));
+    GRAY("회색", 0x9D9D9D),
+    GREEN("초록", 0x1EFF00),
+    BLUE("파랑", 0x0070FF),
+    PURPLE("보라", 0xA335EE),
+    ORANGE("주황", 0xFF8000),
+    PINK("핑크", 0xE268A8),
+    GOLD("골드", 0xE5CC80);
+
+    val accentColor: Color
+        get() = Color(hexColor)
 
     companion object {
         fun fromAllStarPercent(percent: Double?): FFlogParseColorTier {
             if (percent == null) return GRAY
+            val normalized = percent.coerceIn(0.0, 100.0)
 
             return when {
-                percent >= 100.0 -> GOLD
-                percent >= 99.0 -> PINK
-                percent >= 95.0 -> ORANGE
-                percent >= 75.0 -> PURPLE
-                percent >= 50.0 -> BLUE
-                percent >= 25.0 -> GREEN
+                normalized >= 100.0 -> GOLD
+                normalized >= 99.0 -> PINK
+                normalized >= 95.0 -> ORANGE
+                normalized >= 75.0 -> PURPLE
+                normalized >= 50.0 -> BLUE
+                normalized >= 25.0 -> GREEN
                 else -> GRAY
             }
         }

--- a/src/main/kotlin/feature/model/FFlogRankingSummary.kt
+++ b/src/main/kotlin/feature/model/FFlogRankingSummary.kt
@@ -122,5 +122,7 @@ data class FFlogRankingSummary(
     fun allStarPointValueOrDefault(default: Double = -1.0): Double =
         allStarPoint?.substringBefore("/")?.trim()?.toDoubleOrNull() ?: default
 
+    fun allStarPercentValueOrNull(): Double? = allStarPercent?.toDoubleOrNull()
+
 
 }

--- a/src/main/kotlin/feature/model/FFlogRankingSummary.kt
+++ b/src/main/kotlin/feature/model/FFlogRankingSummary.kt
@@ -91,7 +91,7 @@ data class FFlogRankingSummary(
         return when {
             displayInfo != null -> "${displayInfo.emoji} ${displayInfo.koreanName}"
             job != null -> job
-            else -> "직업: N/A"
+            else -> "N/A"
         }
     }
 

--- a/src/test/kotlin/feature/model/FFlogParseColorTierTest.kt
+++ b/src/test/kotlin/feature/model/FFlogParseColorTierTest.kt
@@ -1,0 +1,18 @@
+package feature.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FFlogParseColorTierTest {
+    @Test
+    fun `FFLogs 퍼센트 경계값에 따라 색상 티어가 분류된다`() {
+        assertEquals(FFlogParseColorTier.GRAY, FFlogParseColorTier.fromAllStarPercent(null))
+        assertEquals(FFlogParseColorTier.GRAY, FFlogParseColorTier.fromAllStarPercent(24.9))
+        assertEquals(FFlogParseColorTier.GREEN, FFlogParseColorTier.fromAllStarPercent(25.0))
+        assertEquals(FFlogParseColorTier.BLUE, FFlogParseColorTier.fromAllStarPercent(50.0))
+        assertEquals(FFlogParseColorTier.PURPLE, FFlogParseColorTier.fromAllStarPercent(75.0))
+        assertEquals(FFlogParseColorTier.ORANGE, FFlogParseColorTier.fromAllStarPercent(95.0))
+        assertEquals(FFlogParseColorTier.PINK, FFlogParseColorTier.fromAllStarPercent(99.0))
+        assertEquals(FFlogParseColorTier.GOLD, FFlogParseColorTier.fromAllStarPercent(100.0))
+    }
+}

--- a/src/test/kotlin/feature/model/FFlogParseColorTierTest.kt
+++ b/src/test/kotlin/feature/model/FFlogParseColorTierTest.kt
@@ -7,12 +7,29 @@ class FFlogParseColorTierTest {
     @Test
     fun `FFLogs 퍼센트 경계값에 따라 색상 티어가 분류된다`() {
         assertEquals(FFlogParseColorTier.GRAY, FFlogParseColorTier.fromAllStarPercent(null))
-        assertEquals(FFlogParseColorTier.GRAY, FFlogParseColorTier.fromAllStarPercent(24.9))
+        assertEquals(FFlogParseColorTier.GRAY, FFlogParseColorTier.fromAllStarPercent(24.999))
         assertEquals(FFlogParseColorTier.GREEN, FFlogParseColorTier.fromAllStarPercent(25.0))
+        assertEquals(FFlogParseColorTier.GREEN, FFlogParseColorTier.fromAllStarPercent(49.999))
         assertEquals(FFlogParseColorTier.BLUE, FFlogParseColorTier.fromAllStarPercent(50.0))
+        assertEquals(FFlogParseColorTier.BLUE, FFlogParseColorTier.fromAllStarPercent(74.999))
         assertEquals(FFlogParseColorTier.PURPLE, FFlogParseColorTier.fromAllStarPercent(75.0))
+        assertEquals(FFlogParseColorTier.PURPLE, FFlogParseColorTier.fromAllStarPercent(94.999))
         assertEquals(FFlogParseColorTier.ORANGE, FFlogParseColorTier.fromAllStarPercent(95.0))
+        assertEquals(FFlogParseColorTier.ORANGE, FFlogParseColorTier.fromAllStarPercent(98.999))
         assertEquals(FFlogParseColorTier.PINK, FFlogParseColorTier.fromAllStarPercent(99.0))
+        assertEquals(FFlogParseColorTier.PINK, FFlogParseColorTier.fromAllStarPercent(99.999))
         assertEquals(FFlogParseColorTier.GOLD, FFlogParseColorTier.fromAllStarPercent(100.0))
+        assertEquals(FFlogParseColorTier.GOLD, FFlogParseColorTier.fromAllStarPercent(123.4))
+    }
+
+    @Test
+    fun `각 티어의 색상 코드는 FFLogs_WarcraftLogs 팔레트와 동일하다`() {
+        assertEquals(0x9D9D9D, FFlogParseColorTier.GRAY.hexColor)
+        assertEquals(0x1EFF00, FFlogParseColorTier.GREEN.hexColor)
+        assertEquals(0x0070FF, FFlogParseColorTier.BLUE.hexColor)
+        assertEquals(0xA335EE, FFlogParseColorTier.PURPLE.hexColor)
+        assertEquals(0xFF8000, FFlogParseColorTier.ORANGE.hexColor)
+        assertEquals(0xE268A8, FFlogParseColorTier.PINK.hexColor)
+        assertEquals(0xE5CC80, FFlogParseColorTier.GOLD.hexColor)
     }
 }


### PR DESCRIPTION
## 개요

- FFLogs 조회 기능을 Kord `0.18.0` + Components V2 기반으로 정비하고, 커맨드 입력 UX를 선택형으로 개선했습니다.
- 기존 `/프프로그` 커맨드는 `/로그`로 재정의했으며, 서버/공개여부 입력을 드롭다운으로 바꿔 오입력을 줄였습니다.
- FFLogs/WoWLogs 점수 색상 팔레트를 코드에 명시하고 경계값 테스트를 추가해 색상 표시 일관성을 확보했습니다.

## 주요 변경 사항

- `/프프로그`를 `/로그`로 변경하고, 애플리케이션 시작 시 레거시 `/프프로그` 글로벌 커맨드를 삭제하도록 처리
- `/로그` 인자 스키마 변경
  - `서버`: 코드 내 서버 목록 기반 드롭다운
  - `공개여부`: `공개` / `비공개` 드롭다운
- FFLogs 결과 메시지를 Components V2 컨테이너 기반으로 렌더링하도록 전환
- Parse 색상 티어를 HEX 코드 상수로 정의 (`#9D9D9D`, `#1EFF00`, `#0070FF`, `#A335EE`, `#FF8000`, `#E268A8`, `#E5CC80`)
- 색상 로직 테스트 보강 (구간 경계값 + HEX 코드 일치 검증)
- 애플리케이션 버전 `1.7` 상향

## 커밋 목록

- `8e02af6` 애플리케이션 버전을 1.7로 상향
- `0ec9216` 로그 커맨드 입력 방식을 선택형으로 개편하고 FFLogs 색상 코드를 정합화
- `b0abb53` 프프로그 V2 출력 포맷을 정리하고 직업 아이콘 표시를 복구
- `84b074c` 프프로그 결과를 V2 Component 기반 메시지로 전환
- `96f1d18` FFLogs 점수 퍼센트 기반 색상 티어 분류 로직을 추가
- `c5d25c1` Kord 코어 라이브러리를 0.18.0으로 업데이트

## 통계

- 비교 기준: `origin/main...feat/improve-fflog`
- 변경 파일 수: 6
- 추가/삭제: `+174 / -73`
- 주요 변경 파일:
  - `src/main/kotlin/feature/FFLogRankingFeature.kt`
  - `src/main/kotlin/feature/model/FFlogParseColorTier.kt`
  - `src/test/kotlin/feature/model/FFlogParseColorTierTest.kt`
  - `src/main/kotlin/Main.kt`
  - `build.gradle.kts`

## 참고 사항

- 테스트/검증:
  - `gradle test --tests feature.model.FFlogParseColorTierTest --tests feature.model.FFlogRankingSummaryTest --tests feature.FFlogRankingLogicTest` 성공
- 운영 영향:
  - 글로벌 슬래시 커맨드 이름 변경(`/프프로그` -> `/로그`)으로 사용자 입력 경로가 바뀝니다.
  - 디스코드 글로벌 커맨드 전파 지연이 있을 수 있습니다.
- 호환성:
  - `공개여부`는 문자열 선택형으로 변경했지만 과도기 호환을 위해 기존 boolean 입력도 처리합니다.
